### PR TITLE
Make Audit only show up for Manager role

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -10,13 +10,16 @@
         <nav class="nav">
             <a class="nav-link" href="/ui/cases">Cases</a>
             <a class="nav-link" href="/ui/cases/new">Create</a>
-            <a class="nav-link" href="/ui/audit">Audit</a>
             <a class="nav-link"
-               th:if="${currentActor != null && currentActor.role() != null && currentActor.role().name() == 'MANAGER'}"
+               th:if="${currentActor != null && currentActor.role() != null && currentActor.role().toString() == 'MANAGER'}"
+               href="/ui/audit">Audit</a>
+            <a class="nav-link"
+               th:if="${currentActor != null && currentActor.role() != null && currentActor.role().toString() == 'MANAGER'}"
                href="/ui/patients">Manage Patients</a>
             <a class="nav-link"
-               th:if="${currentActor != null && currentActor.role() != null && currentActor.role().name() == 'MANAGER'}"
+               th:if="${currentActor != null && currentActor.role() != null && currentActor.role().toString() == 'MANAGER'}"
                href="/ui/employees">Manage Users</a></nav>
+
 
         <div class="auth" id="authBar">
             <div th:if="${#authorization.expression('isAuthenticated()')}">


### PR DESCRIPTION
And Update role checks in header to use `toString()` instead of `name()` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed role-based navigation access control. The "Audit" link now correctly displays only for users with manager permissions, consistent with other manager-only navigation options ("Manage Patients" and "Manage Users"). This ensures proper permission-based visibility across navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->