### PR TITLE
fix: add default values to GitHub and S3 credentials placeholders

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,15 +15,15 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 server.forward-headers-strategy=native
 
 # GitHub OAuth2 Login(hide credentials in production)
-spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
-spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:none}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:none}
 spring.security.oauth2.client.registration.github.scope=read:user,user:email
 logging.level.org.springframework.security=INFO
 
 # Cloudflare R2 Configuration
 spring.cloud.aws.s3.endpoint=${S3_ENDPOINT:http://localhost:9000}
-spring.cloud.aws.credentials.access-key=${S3_ACCESS_KEY}
-spring.cloud.aws.credentials.secret-key=${S3_SECRET_KEY}
+spring.cloud.aws.credentials.access-key=${S3_ACCESS_KEY:minioadmin}
+spring.cloud.aws.credentials.secret-key=${S3_SECRET_KEY:minioadmin}
 spring.cloud.aws.region.static=${S3_REGION:auto}
 spring.cloud.aws.s3.path-style-access-enabled=true
 app.s3.bucket=${S3_BUCKET:documents}


### PR DESCRIPTION
#104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration fallback values for GitHub OAuth and cloud storage authentication to streamline initial deployment setup without immediate credential provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->